### PR TITLE
Add Windows tutorial to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 yarn-error.log
 .DS_Store
 package-lock.json
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Switches.mx
+
 ## The MX switches Database
 
 Licensed under: [Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/)
@@ -11,11 +12,170 @@ Reddit: [PM me /u/switchesmx](https://www.reddit.com/message/compose/?to=switche
 
 ## Project structure
 
-The website is built using [Statamic](https://statamic.com/) - the Laravel PHP CMS. I run this locally using [Laravel Homestead](https://laravel.com/docs/8.x/homestead). The beauty of Statamic is that it's all self-contained with no external database; the content is all stored in yaml and markdown files in the `/content` directory.
+The website is built using [Statamic](https://statamic.com/) - the Laravel PHP CMS. It can be run locally using [Laravel Homestead](https://laravel.com/docs/8.x/homestead). The beauty of Statamic is that it's all self-contained with no external database; the content is all stored in yaml and markdown files in the `/content` directory.
 
-To get it running inside a virtual machine you'll need to run `composer install` first.
+## Setting up Switches.mx with Laravel Homestead (Windows)
 
-To build local assets and then to run the watcher:
-- `npm install`
-- `npm run watch-poll`
-- Open [homesteadswitchesmx.test](http://homesteadswitchesmx.test/)
+This tutorial guides you through setting up the Switches.mx project within a Laravel Homestead environment on your Windows machine using Vagrant and VirtualBox.
+
+**Prerequisites:**
+
+* **Install VirtualBox:**
+  * Download a version of VirtualBox for Windows hosts from [virtualbox.org](https://www.virtualbox.org/wiki/Downloads).
+    > [!IMPORTANT]
+    > Check the [supported VirtualBox versions for your Vagrant version](https://developer.hashicorp.com/vagrant/docs/providers/virtualbox) and download a compatible version.
+  * Run the installer and follow the on-screen instructions.
+
+* **Install Vagrant:**
+  * Download the latest version of Vagrant for Windows from [vagrantup.com](https://www.vagrantup.com/downloads.html).
+  * Run the installer and follow the on-screen instructions.
+
+* **Basic terminal knowledge:** You'll be using PowerShell.
+* **Git:** For cloning repositories. Download and install from [git-scm.com](https://git-scm.com/downloads).
+
+**1. Install Homestead:**
+
+* Open PowerShell.
+* Navigate to the directory where you want to create the Homestead folder (e.g., `$HOME\Projects`):
+
+    ```powershell
+    cd $HOME\Projects
+    ```
+
+* Clone the Homestead repository and navigate into it:
+
+    ```powershell
+    git clone https://github.com/laravel/homestead.git Homestead
+    ```
+
+* **Check out the latest stable release:**
+  * `git tag --sort=v:refname` (This lists all tags; look for the latest version number)
+  * Assuming the latest stable release is `v15.x.x`, do:
+
+    ```powershell
+    cd Homestead
+    git checkout v12.x.x
+    ```
+
+* Initialize Homestead: `.\init.ps1`
+
+**2. Generate an SSH key in the default directory:**
+
+* **Homestead needs an SSH key to securely connect to and manage the virtual machine, even though it's hosted locally.**
+* Open a new PowerShell window.
+* Run the following command:
+
+    ```powershell
+    ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+    ```
+
+    Note: You can use any email address or placeholder here. It's mainly for identification.
+* Press Enter to accept the default save location (`$HOME\.ssh\id_rsa`).
+* Optionally set a passphrase (and confirm it if you do).
+
+**3. Configure Homestead:**
+
+* Open `Homestead.yaml` in your Homestead directory (`$HOME\Projects\Homestead`) with a text editor.
+* **Set up a folder mapping:**
+
+    ```yaml
+    folders:
+      - map: C:\Code\switches.mx  # Path to your local project folder
+        to: /home/vagrant/code/switches.mx 
+    ```
+
+* **Configure a site:**
+
+    ```yaml
+    sites:
+      - map: switches.mx.test
+        to: /home/vagrant/code/switches.mx/public
+    ```
+
+* **Set the provider:**
+
+    ```yaml
+    provider: virtualbox
+    ```
+
+* **Add the private key path (default location):**
+
+    ```yaml
+    keys:
+        - ~/.ssh/id_rsa 
+    ```
+
+**4. Update your hosts file:**
+
+* Open `C:\Windows\System32\drivers\etc\hosts` as administrator with a text editor.
+* **Check the `ip` address in your `Homestead.yaml` file. It's usually `192.168.56.56`.**
+* Add the following line, using the IP address from your `Homestead.yaml`:
+
+    ```text
+    192.168.56.56  switches.mx.test
+    ```
+
+**5. Clone the project:**
+
+* Open PowerShell.
+* Navigate to your projects directory (e.g., `C:\Code`)
+
+    ```powershell
+    cd C:\Code
+    ```
+
+* Clone the project from GitHub:
+
+    ```powershell
+    git clone <github-repository-url> switches.mx
+    ```
+
+    Replace `<github-repository-url>` with the actual URL of your GitHub repository (this can be the main repository or your own fork).
+
+**6. Create and set up your `.env` file:**
+
+* Open PowerShell.
+* Navigate to your project directory:
+
+    ```powershell
+    cd C:\Code\switches.mx
+    ```
+
+* Copy the `.env.example` file to create `.env`:
+
+    ```powershell
+    cp .env.example .env
+    ```
+
+* Open the `.env` file with a text editor and set the necessary environment variables (database credentials, etc.).
+
+**7. Start the Vagrant box:**
+
+* Open PowerShell and navigate to your Homestead directory: `cd $HOME\Projects\Homestead`
+* Start the virtual machine: `vagrant up`
+
+**8. SSH into the Vagrant box:**
+
+* In PowerShell, run: `vagrant ssh`
+
+**9. Install Composer dependencies:**
+
+* Navigate to your project directory in the Vagrant box: `cd /home/vagrant/code/switches.mx`
+* Ensure the necessary directories exist and have the correct permissions:
+
+    ```bash
+    mkdir -p storage/framework/cache
+    chmod -R 775 storage
+    chmod -R 775 bootstrap/cache
+    sudo chown -R vagrant:vagrant storage 
+    ```
+
+* Run this command to update and install the required PHP packages:
+
+    ```bash
+    composer update
+    ```
+
+**10. Access your switches.mx site:**
+
+* Open your web browser and visit `switches.mx.test`.


### PR DESCRIPTION
This pull request adds a detailed tutorial on setting up the Switches.mx project using Laravel Homestead in a Vagrant environment with VirtualBox on Windows. I've had my troubles doing this, so I want to make it easier for any future contributors.

The tutorial covers the following steps:

- Installing VirtualBox and Vagrant
- Installing Homestead
- Generating an SSH key
- Configuring Homestead
- Updating the hosts file
- Cloning the project from GitHub
- Creating and setting up the `.env` file
- Starting the Vagrant box
- SSHing into the Vagrant box
- Installing Composer dependencies
- Accessing the Switches.mx site

Gitignore was changed too and I am unable to divide those two commits, sorry.
The [!IMPORTANT] block in the "Install VirtualBox" doesn't work properly and I have no idea why. But I left it in because it still draws attention the way it currently is.